### PR TITLE
Agregando cliente HTTP en msvc-usuarios

### DIFF
--- a/src/main/java/com/angel/springcloud/msvc/usuarios/MsvcUsuariosApplication.java
+++ b/src/main/java/com/angel/springcloud/msvc/usuarios/MsvcUsuariosApplication.java
@@ -2,7 +2,9 @@ package com.angel.springcloud.msvc.usuarios;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class MsvcUsuariosApplication {
 

--- a/src/main/java/com/angel/springcloud/msvc/usuarios/clients/CursoClientRest.java
+++ b/src/main/java/com/angel/springcloud/msvc/usuarios/clients/CursoClientRest.java
@@ -1,0 +1,13 @@
+package com.angel.springcloud.msvc.usuarios.clients;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "msvc-cursos", url = "localhost:8002")
+public interface CursoClientRest {
+
+    @DeleteMapping("/eliminar-curso-usuario/{id}")
+    void eliminarCursoUsuarioPorId(@PathVariable Long id);
+
+}

--- a/src/main/java/com/angel/springcloud/msvc/usuarios/controllers/UsuarioController.java
+++ b/src/main/java/com/angel/springcloud/msvc/usuarios/controllers/UsuarioController.java
@@ -151,6 +151,11 @@ public class UsuarioController {
     }
 
     @GetMapping("/usuarios-por-curso")
+    @Operation(summary = "Obtener todos los usuarios por curso", description = "Devuelve una lista de usuarios por curso")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Usuarios obtenidos correctamente"),
+            @ApiResponse(responseCode = "500", description = "Error interno del servidor")
+    })
     public ResponseEntity<?> obtenerUsuariosPorCurso(@RequestParam List<Long> ids) {
         return ResponseEntity.ok(usuarioService.listarPorIds(ids));
     }

--- a/src/main/java/com/angel/springcloud/msvc/usuarios/services/UsuarioServiceImpl.java
+++ b/src/main/java/com/angel/springcloud/msvc/usuarios/services/UsuarioServiceImpl.java
@@ -1,5 +1,6 @@
 package com.angel.springcloud.msvc.usuarios.services;
 
+import com.angel.springcloud.msvc.usuarios.clients.CursoClientRest;
 import com.angel.springcloud.msvc.usuarios.entities.Usuario;
 import com.angel.springcloud.msvc.usuarios.repositories.UsuarioRepository;
 import org.springframework.stereotype.Service;
@@ -12,9 +13,11 @@ import java.util.Optional;
 public class UsuarioServiceImpl implements UsuarioService {
 
     private final UsuarioRepository repository;
+    private final CursoClientRest cursoClientRest;
 
-    public UsuarioServiceImpl(UsuarioRepository repository) {
+    public UsuarioServiceImpl(UsuarioRepository repository, CursoClientRest cursoClientRest) {
         this.repository = repository;
+        this.cursoClientRest = cursoClientRest;
     }
 
     @Override
@@ -50,6 +53,7 @@ public class UsuarioServiceImpl implements UsuarioService {
     @Transactional
     public void eliminar(Long id) {
         repository.deleteById(id);
+        cursoClientRest.eliminarCursoUsuarioPorId(id);
     }
 
     @Override


### PR DESCRIPTION
Se agrega el cliente feign HTTP en el msvc-usuarios, esto para implementar el metodo de eliminación de usuarios entre los dos microservicios, donde se elimina el usuario ademas de quitarlo de dicho curso en el que estaba.

Clases e interfaces modificadas:

- MsvcUsuariosApplication.java
- CursoClientRest.java
- UsuarioController.java
- UsuarioServiceImpl.java